### PR TITLE
Adding dependency - type definitions for mocha.

### DIFF
--- a/services/todo-legacy/package.json
+++ b/services/todo-legacy/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "@loopback/testlab": "^4.0.0-alpha.6",
-    "mocha": "^3.3.0"
+    "mocha": "^3.3.0",
+    "@types/mocha": "^2.2.41"
   },
   "dependencies": {
     "@loopback/core": "^4.0.0-alpha.10",


### PR DESCRIPTION
### Description

Fix to 'npm test' which gives error for todo-legacy service as because of missing types definitions for mocha. 

- connect to #71 
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
