### PR TITLE
Added application names to app.info() to identify the ports.

### DIFF
--- a/services/account-without-juggler/index.ts
+++ b/services/account-without-juggler/index.ts
@@ -23,6 +23,7 @@ class AccountMicroservice extends Application {
     const port: Number = await this.get('http.port');
 
     return {
+      appName: "account-without-juggler",
       uptime: Date.now() - this._startTime.getTime(),
       url: 'http://127.0.0.1:' + port,
     };

--- a/services/account/index.ts
+++ b/services/account/index.ts
@@ -20,6 +20,7 @@ class AccountMicroservice extends Application {
     const port: Number = await this.get('http.port');
 
     return {
+      appName: "account",
       uptime: Date.now() - this._startTime.getTime(),
       url: 'http://127.0.0.1:' + port,
     };

--- a/services/customer/index.ts
+++ b/services/customer/index.ts
@@ -20,6 +20,7 @@ class CustomerApplication extends Application {
     const port: Number = await this.get('http.port');
 
     return {
+      appName: "customer",
       uptime: Date.now() - this._startTime.getTime(),
       url: 'http://127.0.0.1:' + port,
     };

--- a/services/facade/index.ts
+++ b/services/facade/index.ts
@@ -18,6 +18,7 @@ class FacadeMicroservice extends Application {
     const port: Number = await this.get('http.port');
 
     return {
+      appName: "facade",
       uptime: Date.now() - this._startTime.getTime(),
       url: 'http://127.0.0.1:' + port,
     };

--- a/services/todo-legacy/application.ts
+++ b/services/todo-legacy/application.ts
@@ -34,6 +34,7 @@ export class TodoApplication extends Application {
     const port: Number = await this.get('http.port');
 
     return JSON.stringify({
+      appName: "todo-legecy",
       uptime: Date.now() - this._startTime.getTime(),
       url: 'http://127.0.0.1:' + port,
     }, null, 2);

--- a/services/transaction/index.ts
+++ b/services/transaction/index.ts
@@ -20,6 +20,7 @@ class TransactionApplication extends Application {
     const port: Number = await this.get('http.port');
 
     return {
+      appName: "transaction",
       uptime: Date.now() - this._startTime.getTime(),
       url: 'http://127.0.0.1:' + port,
     };


### PR DESCRIPTION
### Description

When executing `npm start`, console information is not mentioning the port number belongs to which application. So, added application names to app.info() to identify the ports.

Now console will displays:

`Application Info: { appName: 'customer', uptime: 12, url: 'http://127.0.0.1:3002' }`